### PR TITLE
Fix problem with a build error.

### DIFF
--- a/src/main/java/org/mcphoton/impl/command/ListCommand.java
+++ b/src/main/java/org/mcphoton/impl/command/ListCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2016 MCPhoton <http://mcphoton.org> and contributors.
+ *
+ * This file is part of the Photon Server Implementation <https://github.com/mcphoton/Photon-Server>.
+ *
+ * The Photon Server Implementation is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Photon Server Implementation is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.mcphoton.impl.command;
 
 import org.mcphoton.command.Command;


### PR DESCRIPTION
Error with Gradle at task 'licenseMain': "Missing header in: src\main\java\org\mcphoton\impl\command\ListCommand.java"

Complete error: 

```
$ gradle build
:Photon-API:compileJava UP-TO-DATE
:Photon-API:processResources UP-TO-DATE
:Photon-API:classes UP-TO-DATE
:Photon-API:jar UP-TO-DATE
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jar UP-TO-DATE
:assemble UP-TO-DATE
:licenseMain
Missing header in: src\main\java\org\mcphoton\impl\command\ListCommand.java
:licenseMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':licenseMain'.
> License violations were found: J:\Users\w67clement\Workspace\Git\Minecraft\Photon\Photon-Server\src\main\java\org\mcphoton\impl\command\ListCommand.java}

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 3.037 secs
```

It's a fix.
